### PR TITLE
Enable build Julia 1.3.0 for rpi2 and rpi3

### DIFF
--- a/rpi2/Dockerfile-1.3.0
+++ b/rpi2/Dockerfile-1.3.0
@@ -1,0 +1,32 @@
+# Build Julia binary for arm32-bit armv7-a devices e.g. RaspberryPi 2 or 3
+
+FROM balenalib/raspberry-pi2:stretch-run-20181207
+MAINTAINER SATOSHI TERASAKI
+
+# insta dependencies
+RUN apt-get update && \
+    apt-get install -y build-essential libatomic1 python gfortran perl wget m4 cmake pkg-config \
+    git
+
+# build julia from source
+ARG JL_VERSION="v1.3.0"
+ARG WDIR=/home/pi/work
+ARG JL_BUILD_DIR=$WDIR/build
+WORKDIR $WDIR
+RUN echo "\
+JULIA_CPU_TARGET=cortex-a7\n\
+MARCH=armv7-a\n\
+CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0\n\
+prefix=$WDIR/julia-$JL_VERSION\n\
+" > Make.user && \
+    cat Make.user && \
+    git clone --depth=1 -b $JL_VERSION https://github.com/JuliaLang/julia.git $JL_BUILD_DIR &&\
+    cp Make.user $JL_BUILD_DIR && \
+    cd $JL_BUILD_DIR && make -j 16 && make install
+
+# add path of Julia
+ENV PATH=$WDIR/julia-$JL_VERSION/bin:$PATH
+
+# clean up
+RUN rm -r $JL_BUILD_DIR $WDIR/Make.user
+RUN apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*

--- a/rpi2/docker-compose.yml
+++ b/rpi2/docker-compose.yml
@@ -12,3 +12,7 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile-1.2.0
+  1.3.0:
+    build:
+      context: ./
+      dockerfile: Dockerfile-1.3.0

--- a/rpi3/Dockerfile-1.3.0
+++ b/rpi3/Dockerfile-1.3.0
@@ -1,0 +1,33 @@
+# Build Julia binary for arm32-bit armv7-a devices e.g. RaspberryPi 2 or 3
+
+FROM balenalib/raspberrypi3:stretch-run-20181207
+
+MAINTAINER SATOSHI TERASAKI
+
+# insta dependencies
+RUN apt-get update && \
+    apt-get install -y build-essential libatomic1 python gfortran perl wget m4 cmake pkg-config \
+    git
+
+# build julia from source
+ARG JL_VERSION="v1.3.0"
+ARG WDIR=/home/pi/work
+ARG JL_BUILD_DIR=$WDIR/build
+WORKDIR $WDIR
+RUN echo "\
+JULIA_CPU_TARGET=cortex-a7\n\
+MARCH=armv7-a\n\
+CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0\n\
+prefix=$WDIR/julia-$JL_VERSION\n\
+" > Make.user && \
+    cat Make.user && \
+    git clone --depth=1 -b $JL_VERSION https://github.com/JuliaLang/julia.git $JL_BUILD_DIR &&\
+    cp Make.user $JL_BUILD_DIR && \
+    cd $JL_BUILD_DIR && make -j 16 && make install
+
+# add path of Julia
+ENV PATH=$WDIR/julia-$JL_VERSION/bin:$PATH
+
+# clean up
+RUN rm -r $JL_BUILD_DIR $WDIR/Make.user
+RUN apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*

--- a/rpi3/docker-compose.yml
+++ b/rpi3/docker-compose.yml
@@ -12,3 +12,7 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile-1.2.0
+  1.3.0:
+    build:
+      context: ./
+      dockerfile: Dockerfile-1.3.0


### PR DESCRIPTION
This PR provides Dockerfile to build Julia 1.3.0 for RaspberryPi 2 and 3