### PR TITLE
ignore files generated by mac/Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.jl.*.cov
 *.jl.mem
 deps/deps.jl
+mac/build_error.txt
+mac/build_log.txt
+mac/julia/


### PR DESCRIPTION
Ignore the following file/directory generated by mac/Makefile

- mac/build_error.txt
- mac/build_log.txt
- mac/julia