### PR TITLE
have a try 1.5.0-rc1

### DIFF
--- a/rpi3/Dockerfile-v1.5.0-rc1
+++ b/rpi3/Dockerfile-v1.5.0-rc1
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 
 # build julia from source
-ARG JL_VERSION="v1.4.2"
+ARG JL_VERSION="v1.5.0-rc1"
 ARG WDIR=/home/pi/work
 ARG JL_BUILD_DIR=$WDIR/build
 WORKDIR $WDIR
@@ -19,7 +19,7 @@ RUN echo "\
 CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0\n\
 prefix=/home/pi/julia-$JL_VERSION\n\
 USE_BINARYBUILDER=0\n\
-USE_GPL_LIBS=0\n\
+JULIA_PRECOMPILE=0\n\
 LDFLAGS=-latomic\n\
 CFLAGS += "-mfpu=neon-vfpv4"\n\
 CXXFLAGS += "-mfpu=neon-vfpv4"\n\

--- a/rpi3/Dockerfile-v1.5.0-rc1
+++ b/rpi3/Dockerfile-v1.5.0-rc1
@@ -7,30 +7,36 @@ MAINTAINER SATOSHI TERASAKI
 # insta dependencies
 RUN apt-get update && \
     apt-get install -y build-essential libatomic1 python gfortran perl wget m4 cmake pkg-config \
-    git
+    git && \
+    apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 
 # build julia from source
-ARG JL_VERSION="v1.5.0-rc1"
+ARG JL_VERSION="v1.4.2"
 ARG WDIR=/home/pi/work
 ARG JL_BUILD_DIR=$WDIR/build
 WORKDIR $WDIR
 RUN echo "\
-JULIA_CPU_TARGET=cortex-a7\n\
-USE_BINARYBUILDER=0\n\
-JULIA_PRECOMPILE=0\n\
-MARCH=armv7-a\n\
 CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0\n\
-prefix=$WDIR/julia-$JL_VERSION\n\
+prefix=/home/pi/julia-$JL_VERSION\n\
+USE_BINARYBUILDER=0\n\
+USE_GPL_LIBS=0\n\
+LDFLAGS=-latomic\n\
+CFLAGS += "-mfpu=neon-vfpv4"\n\
+CXXFLAGS += "-mfpu=neon-vfpv4"\n\
+MARCH="armv7-a"\n\
+JULIA_CPU_TARGET=\"armv7-a\;armv7-a,neon\;armv7-a,neon,vfp4\"\n\
+JULIA_CPU_THREADS=4\n\
 " > Make.user && \
     cat Make.user && \
     git clone --depth=1 -b $JL_VERSION https://github.com/JuliaLang/julia.git $JL_BUILD_DIR &&\
     cp Make.user $JL_BUILD_DIR && \
-    cd $JL_BUILD_DIR && make -j 16 && make install
+    cd $JL_BUILD_DIR && make -j 16 && make install && \
+    echo "clean up $JL_BUILD_DIR" && \
+    rm -r $JL_BUILD_DIR && \
+    echo "Done"
 
 # add path of Julia
-ENV PATH=$WDIR/julia-$JL_VERSION/bin:$PATH
-
-# clean up
-RUN rm -r $JL_BUILD_DIR $WDIR/Make.user
-RUN apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
-
+ENV PATH=/home/pi/julia-$JL_VERSION/bin:$PATH
+# runtime test
+RUN julia -e "using InteractiveUtils; versioninfo()"
+CMD ["julia"]

--- a/rpi3/Dockerfile-v1.5.0-rc1
+++ b/rpi3/Dockerfile-v1.5.0-rc1
@@ -1,0 +1,36 @@
+# Build Julia binary for arm32-bit armv7-a devices e.g. RaspberryPi 2 or 3
+
+FROM balenalib/raspberrypi3:buster-20200502
+
+MAINTAINER SATOSHI TERASAKI
+
+# insta dependencies
+RUN apt-get update && \
+    apt-get install -y build-essential libatomic1 python gfortran perl wget m4 cmake pkg-config \
+    git
+
+# build julia from source
+ARG JL_VERSION="v1.5.0-rc1"
+ARG WDIR=/home/pi/work
+ARG JL_BUILD_DIR=$WDIR/build
+WORKDIR $WDIR
+RUN echo "\
+JULIA_CPU_TARGET=cortex-a7\n\
+USE_BINARYBUILDER=0\n\
+JULIA_PRECOMPILE=0\n\
+MARCH=armv7-a\n\
+CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0\n\
+prefix=$WDIR/julia-$JL_VERSION\n\
+" > Make.user && \
+    cat Make.user && \
+    git clone --depth=1 -b $JL_VERSION https://github.com/JuliaLang/julia.git $JL_BUILD_DIR &&\
+    cp Make.user $JL_BUILD_DIR && \
+    cd $JL_BUILD_DIR && make -j 16 && make install
+
+# add path of Julia
+ENV PATH=$WDIR/julia-$JL_VERSION/bin:$PATH
+
+# clean up
+RUN rm -r $JL_BUILD_DIR $WDIR/Make.user
+RUN apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
+

--- a/rpi3/Dockerfile-v1.5.0-rc1
+++ b/rpi3/Dockerfile-v1.5.0-rc1
@@ -19,7 +19,6 @@ RUN echo "\
 CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0\n\
 prefix=/home/pi/julia-$JL_VERSION\n\
 USE_BINARYBUILDER=0\n\
-JULIA_PRECOMPILE=0\n\
 LDFLAGS=-latomic\n\
 CFLAGS += "-mfpu=neon-vfpv4"\n\
 CXXFLAGS += "-mfpu=neon-vfpv4"\n\
@@ -30,6 +29,11 @@ JULIA_CPU_THREADS=4\n\
     cat Make.user && \
     git clone --depth=1 -b $JL_VERSION https://github.com/JuliaLang/julia.git $JL_BUILD_DIR &&\
     cp Make.user $JL_BUILD_DIR && \
+    # add patches
+    sed -i -e '69s/devnull/stdout/' ${JL_BUILD_DIR}/contrib/generate_precompile.jl && \
+    sed -i -e '63,65 s/^/#/'     ${JL_BUILD_DIR}/contrib/generate_precompile.jl && \
+    sed -i -e '190 s/^/#/'       ${JL_BUILD_DIR}/contrib/generate_precompile.jl && \
+    cat ${JL_BUILD_DIR}/contrib/generate_precompile.jl && \
     cd $JL_BUILD_DIR && make -j 16 && make install && \
     echo "clean up $JL_BUILD_DIR" && \
     rm -r $JL_BUILD_DIR && \

--- a/rpizero/Dockerfile-v1.5.0-rc1
+++ b/rpizero/Dockerfile-v1.5.0-rc1
@@ -25,7 +25,6 @@ JULIA_CPU_TARGET=arm1176jzf-s\n\
 LDFLAGS=-latomic\n\
 USE_BINARYBUILDER=0\n\
 JULIA_PRECOMPILE=0\n\
-USE_GPL_LIBS=0\n\
 override USE_SYSTEM_BLAS=1\n\
 override USE_SYSTEM_LAPACK=1\n\
 override USE_SYSTEM_LIBM=1\n\
@@ -38,12 +37,10 @@ override USE_SYSTEM_MPFR=1\n\
     cd $JL_BUILD_DIR && make -j 16 OPENBLAS_USE_THREAD=0 && make install && \
     rm -r $JL_BUILD_DIR && \
     echo "Done"
-
+    
 # add path of Julia
 ENV PATH=/home/pi/julia-$JL_VERSION/bin:$PATH
 # runtime test
 RUN julia -e "using InteractiveUtils; versioninfo()"
 CMD ["julia"]
-
-
 

--- a/rpizero/Dockerfile-v1.5.0-rc1
+++ b/rpizero/Dockerfile-v1.5.0-rc1
@@ -1,5 +1,7 @@
 # Build Julia binary for arm32-bit devices e.g. RaspberryPi Zero(W/WH)
+
 FROM balenalib/raspberry-pi:buster-20200518
+
 MAINTAINER SATOSHI TERASAKI
 
 # install dependencies
@@ -9,7 +11,8 @@ RUN apt-get update && \
     liblapack-dev \
     libgmp3-dev \
     libmpfr-dev \
-    git
+    git && \
+    apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 
 # build julia from source
 ARG JL_VERSION="v1.5.0-rc1"
@@ -17,11 +20,12 @@ ARG WDIR=/home/pi/work
 ARG JL_BUILD_DIR=$WDIR/build
 WORKDIR $WDIR
 RUN echo "\
-prefix=$WDIR/julia-$JL_VERSION\n\
+prefix=/home/pi/julia-$JL_VERSION\n\
 JULIA_CPU_TARGET=arm1176jzf-s\n\
 LDFLAGS=-latomic\n\
 USE_BINARYBUILDER=0\n\
 JULIA_PRECOMPILE=0\n\
+USE_GPL_LIBS=0\n\
 override USE_SYSTEM_BLAS=1\n\
 override USE_SYSTEM_LAPACK=1\n\
 override USE_SYSTEM_LIBM=1\n\
@@ -31,11 +35,15 @@ override USE_SYSTEM_MPFR=1\n\
     cat Make.user && \
     git clone --depth=1 -b $JL_VERSION https://github.com/JuliaLang/julia.git $JL_BUILD_DIR &&\
     cp Make.user $JL_BUILD_DIR && \
-    cd $JL_BUILD_DIR && make -j 16 OPENBLAS_USE_THREAD=0 && make install
+    cd $JL_BUILD_DIR && make -j 16 OPENBLAS_USE_THREAD=0 && make install && \
+    rm -r $JL_BUILD_DIR && \
+    echo "Done"
 
 # add path of Julia
-ENV PATH=$WDIR/julia-$JL_VERSION/bin:$PATH
+ENV PATH=/home/pi/julia-$JL_VERSION/bin:$PATH
+# runtime test
+RUN julia -e "using InteractiveUtils; versioninfo()"
+CMD ["julia"]
 
-# clean up
-RUN rm -r $JL_BUILD_DIR $WDIR/Make.user
-RUN apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
+
+

--- a/rpizero/Dockerfile-v1.5.0-rc1
+++ b/rpizero/Dockerfile-v1.5.0-rc1
@@ -34,6 +34,11 @@ override USE_SYSTEM_MPFR=1\n\
     cat Make.user && \
     git clone --depth=1 -b $JL_VERSION https://github.com/JuliaLang/julia.git $JL_BUILD_DIR &&\
     cp Make.user $JL_BUILD_DIR && \
+    # add patches
+    sed -i -e '69s/devnull/stdout/' ${JL_BUILD_DIR}/contrib/generate_precompile.jl && \
+    sed -i -e '63,65 s/^/#/'     ${JL_BUILD_DIR}/contrib/generate_precompile.jl && \
+    sed -i -e '190 s/^/#/'       ${JL_BUILD_DIR}/contrib/generate_precompile.jl && \
+    cat ${JL_BUILD_DIR}/contrib/generate_precompile.jl && \
     cd $JL_BUILD_DIR && make -j 16 OPENBLAS_USE_THREAD=0 && make install && \
     rm -r $JL_BUILD_DIR && \
     echo "Done"

--- a/rpizero/Dockerfile-v1.5.0-rc1
+++ b/rpizero/Dockerfile-v1.5.0-rc1
@@ -1,0 +1,41 @@
+# Build Julia binary for arm32-bit devices e.g. RaspberryPi Zero(W/WH)
+FROM balenalib/raspberry-pi:buster-20200518
+MAINTAINER SATOSHI TERASAKI
+
+# install dependencies
+RUN apt-get update && \
+    apt-get install -y build-essential libatomic1 python gfortran perl wget m4 cmake pkg-config \
+    libopenblas-dev \
+    liblapack-dev \
+    libgmp3-dev \
+    libmpfr-dev \
+    git
+
+# build julia from source
+ARG JL_VERSION="v1.5.0-rc1"
+ARG WDIR=/home/pi/work
+ARG JL_BUILD_DIR=$WDIR/build
+WORKDIR $WDIR
+RUN echo "\
+prefix=$WDIR/julia-$JL_VERSION\n\
+JULIA_CPU_TARGET=arm1176jzf-s\n\
+LDFLAGS=-latomic\n\
+USE_BINARYBUILDER=0\n\
+JULIA_PRECOMPILE=0\n\
+override USE_SYSTEM_BLAS=1\n\
+override USE_SYSTEM_LAPACK=1\n\
+override USE_SYSTEM_LIBM=1\n\
+override USE_SYSTEM_GMP=1\n\
+override USE_SYSTEM_MPFR=1\n\
+" > Make.user && \
+    cat Make.user && \
+    git clone --depth=1 -b $JL_VERSION https://github.com/JuliaLang/julia.git $JL_BUILD_DIR &&\
+    cp Make.user $JL_BUILD_DIR && \
+    cd $JL_BUILD_DIR && make -j 16 OPENBLAS_USE_THREAD=0 && make install
+
+# add path of Julia
+ENV PATH=$WDIR/julia-$JL_VERSION/bin:$PATH
+
+# clean up
+RUN rm -r $JL_BUILD_DIR $WDIR/Make.user
+RUN apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*


### PR DESCRIPTION
This PR adds Dockerfile that builds Julia 1.5.0-rc1 for Armv7/Armv6 devices.

You can try pre-build binary via 

```
# rpi3
docker pull terasakisatoshi/jlcross:rpi3-v1.5.0-rc1
# rpizero
docker pull terasakisatoshi/jlcross:rpizero-v1.5.0-rc1
```

Note that we've added `JULIA_PRECOMPILE=0` to Make.user to pass building procedure, otherwise we can't finish.

This issue may happens to Tier3's system. I think https://github.com/JuliaLang/julia/issues/33842 happens again.

```
Base  ───────────227.233298 seconds
Base64  ───────── 21.916886 seconds
CRC32c  ─────────  0.090803 seconds
SHA  ────────────  1.372108 seconds
FileWatching  ───  0.601783 seconds
Unicode  ────────  0.038136 seconds
Mmap  ───────────  0.711052 seconds
Serialization  ──  2.715313 seconds
Libdl  ──────────  0.197182 seconds
Printf  ─────────  2.193781 seconds
Markdown  ─────── 10.687471 seconds
LibGit2  ──────── 13.036388 seconds
Logging  ────────  0.397586 seconds
Sockets  ────────  2.877765 seconds
Profile  ────────  2.040841 seconds
Dates  ────────── 20.438833 seconds
DelimitedFiles  ─  0.716780 seconds
Random  ─────────  4.209028 seconds
UUIDs  ──────────  0.144898 seconds
Future  ─────────  0.024709 seconds
LinearAlgebra  ── 71.450742 seconds
SparseArrays  ─── 32.784123 seconds
SuiteSparse  ────  7.635411 seconds
Distributed  ────  6.458067 seconds
SharedArrays  ───  1.183572 seconds
Pkg  ────────────105.492334 seconds
Test  ───────────  6.821165 seconds
REPL  ───────────  0.000947 seconds
Statistics  ─────  1.560295 seconds
Stdlibs total  ──317.972035 seconds
Sysimage built. Summary:
Total ─────── 545.205984 seconds
Base: ─────── 227.233298 seconds 41.6784%
Stdlibs: ──── 317.972035 seconds 58.3215%
# <-----Stops forever
```