### PR TITLE
remove patch for 1.4.1

### DIFF
--- a/x86-64/Dockerfile
+++ b/x86-64/Dockerfile
@@ -36,8 +36,6 @@ USE_BINARYBUILDER = 0\n\
     && cd julia-$JL_VERSION \
     && make -j $(nproc) \
     && make install \
-    && echo "copy missing dependency from original directory" \
-    && cp $JL_BUILD_DIR/julia-$JL_VERSION/usr/lib/libLLVM-8jl.so /usr/local/julia-$JL_VERSION/lib/ \
     && echo "clean up $JL_BUILD_DIR" \
     && rm -r $JL_BUILD_DIR \
     && echo "Done"
@@ -47,4 +45,3 @@ ENV PATH=/usr/local/julia-$JL_VERSION/bin:$PATH
 RUN julia -e "using InteractiveUtils; versioninfo()"
 
 CMD ["julia"]
-

--- a/x86-64/Dockerfile-gpu
+++ b/x86-64/Dockerfile-gpu
@@ -34,8 +34,6 @@ USE_BINARYBUILDER = 0\n\
     && cd julia-$JL_VERSION \
     && make -j $(nproc) \
     && make install \
-    && echo "copy missing dependency from original directory" \
-    && cp $JL_BUILD_DIR/julia-$JL_VERSION/usr/lib/libLLVM-8jl.so /usr/local/julia-$JL_VERSION/lib/ \
     && echo "clean up $JL_BUILD_DIR" \
     && rm -r $JL_BUILD_DIR \
     && echo "Done"


### PR DESCRIPTION
remove patches applied files under `x86-64`. we do not have to add lines

```
&& echo "copy missing dependency from original directory" \
&& cp $JL_BUILD_DIR/julia-$JL_VERSION/usr/lib/libLLVM-8jl.so /usr/local/julia-$JL_VERSION/lib/ \
```